### PR TITLE
[BUG Report]: Update mkvec_cc2.cpp

### DIFF
--- a/mesh_pipeline/Mesh_pipeline_exact_src/mkvec_cc2.cpp
+++ b/mesh_pipeline/Mesh_pipeline_exact_src/mkvec_cc2.cpp
@@ -49,7 +49,7 @@ double target_edge_length = 6.0;//4.0;//0.04;               // arbitrary remeshi
 unsigned int nb_iter = 2;//3;
 
 
-size_t make_vector_of_connected_components(
+void make_vector_of_connected_components(
     Mesh pmesh, 
     pair<int, int> pair_,
     vector<Mesh> &mesh_vec, 


### PR DESCRIPTION
First, Thanks for your work in multi-material simulation with sofa framework. And it exists a small bug when I compile and run with my Mac. `98826 trace trap` will be printed in the terminal and finished in the `mkvec` function, and I modified the return type of the `make_vector_of_connected_components` function, then it works. Anyway, thanks for your open-source work.
Best wishes!